### PR TITLE
[Feature/0729-21-branch] 商品ページから概要を取得できるようにselenium を使用

### DIFF
--- a/amazon_ranking.py
+++ b/amazon_ranking.py
@@ -35,7 +35,7 @@ _DEFAULT_BEAUTIFULSOUP_PARSER = "html.parser"
 _TODAY = datetime.datetime.now().strftime('%Y.%m.%d-%H-%M')
 
 _INFO_SUM = '8'
-_DEBUG_FLAG = '1' #ON='1' OFF='0'
+_DEBUG_FLAG = '0' #ON='1' OFF='0'
 _DEBUG_VIEW = '1' #ON='1' OFF='0'
 
 info = []


### PR DESCRIPTION
#最低限の概要
1. 商品ページの取得にseleniumを使用
2. デバックモード,デバック表示モードを実装
3. 全体的なコードの見直し
4. 取得項目に概要(SUMMARY)を追加し,取得項目の数を7→8に変更

#mergeを受け入れる条件
特に無し