### PR TITLE
[Feature/0801-17-branch]  スクレイピングのヘッドレス化,APIサーバの作成:ポート3000

### DIFF
--- a/amazon_ranking.py
+++ b/amazon_ranking.py
@@ -7,6 +7,7 @@ import datetime
 import pandas as pd
 import json
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options #headlessオプションに使用
 
 
 # Amazon ランキング　
@@ -69,8 +70,12 @@ class get_sous:
         time.sleep(5)
 
 def open_selenium(load_url):
-	webd=webdriver.Chrome(_DRIVER)
+	# ブラウザーの設定
+	option = Options()
+	option.add_argument('--headless')
+	webd=webdriver.Chrome(_DRIVER,options=option)
 	open1=get_sous(load_url,webd)
+	# ブラウザーの起動
 	open1.openurl()
 	sous1=open1.getbrowser()
 	soup=BeautifulSoup(sous1, 'html.parser')
@@ -191,9 +196,15 @@ def get_info(ele):
 def write(_dict,_list):
 	time.sleep(2)
 	# utf-8で書き込み
-	with open('Amazon' + str(_TODAY) + '.json', 'w', encoding='utf-8_sig') as fp:
+	with open('Amazon' + str(_TODAY) + '_id付' + '.json', 'w', encoding='utf-8_sig') as fp:
 		# 辞書(info)をインデントをつけてアスキー文字列ではない形で保存
 	    json.dump(_dict, fp, indent=int(_INFO_SUM), ensure_ascii=False )
+	# 書き込みオブジェクトを閉じる
+	fp.close()
+	# utf-8で書き込み
+	with open('Amazon' + str(_TODAY) + '.json', 'w', encoding='utf-8_sig') as fp:
+		# 辞書(info)をインデントをつけてアスキー文字列ではない形で保存
+	    json.dump(_list, fp, indent=int(_INFO_SUM), ensure_ascii=False )
 	# 書き込みオブジェクトを閉じる
 	fp.close()
 

--- a/amazon_ranking.py
+++ b/amazon_ranking.py
@@ -141,7 +141,8 @@ def get_info(ele):
 	MAIN_PAGE_tag = ele.find("span", class_="aok-inline-block zg-item")
 	MAIN_PAGE_URL = MAIN_PAGE_tag.find("a", class_="a-link-normal").get("href")
 
-	# 作品ページから無駄な文字列の削除
+	PRICE = PRICE[1:]
+	# 作品ページURLから無駄な文字列の削除
 	idx = MAIN_PAGE_URL.find(_TARGET_WORD_1)  # 半角空白文字のインデックスを検索
 	# 検索文字列の先頭文字の場所が idxに格納される
 	#retext = MAIN_PAGE_URL[idx+3:idx+13] #dp/の3文字分をずらしてURLから10文字分スライス

--- a/eclipse.py
+++ b/eclipse.py
@@ -1,5 +1,5 @@
 import json
-_DEBUG_FILE = 'ama.json' #出力したいjsonファイル
+_DEBUG_FILE = 'Amazon2021.08.02-04-20.json' #出力したいjsonファイル
 
 
 # Eclipse IDE専用プログラム出力
@@ -13,7 +13,7 @@ with open(_DEBUG_FILE, 'r', encoding='utf-8_sig') as f:
 for jsn_val in jsn.values():
     print("map = new HashMap<>();")
     print('map.put("ranking"' + "," + '"' + jsn_val["ranking"] + '");')
-    print('map.put("name"' + "," + '"' + jsn_val["title"] + '");')
+    print('map.put("title"' + "," + '"' + jsn_val["title"] + '");')
     print('map.put("author"' + "," + '"' + jsn_val["author"] + '");')
     print('map.put("price"' + "," + '"' + jsn_val["price"] + '");')
     print('map.put("img"' + "," + '"' + jsn_val["img"] + '");')

--- a/eclipse.py
+++ b/eclipse.py
@@ -1,0 +1,30 @@
+import json
+_DEBUG_FILE = 'ama.json' #出力したいjsonファイル
+
+
+# Eclipse IDE専用プログラム出力
+
+
+with open(_DEBUG_FILE, 'r', encoding='utf-8_sig') as f:
+    jsn = json.load(f)
+
+
+
+for jsn_val in jsn.values():
+    print("map = new HashMap<>();")
+    print('map.put("ranking"' + "," + '"' + jsn_val["ranking"] + '");')
+    print('map.put("name"' + "," + '"' + jsn_val["title"] + '");')
+    print('map.put("author"' + "," + '"' + jsn_val["author"] + '");')
+    print('map.put("price"' + "," + '"' + jsn_val["price"] + '");')
+    print('map.put("img"' + "," + '"' + jsn_val["img"] + '");')
+    print('map.put("asin"' + "," + '"' + jsn_val["asin"] + '");')
+    print('map.put("url"' + "," + '"' + jsn_val["url"] + '");')
+    print('map.put("summary"' + "," + '"' + jsn_val["summary"] + '");')
+    print('map.put("release"' + "," + '"' + jsn_val["release"] + '");')
+    print('map.put("publisher"' + "," + '"' + jsn_val["publisher"] + '");')
+    print('bookList.add(map);')
+    print(' ')
+    print(' ')
+
+print('---------------------')
+#print(jsn["id_99"])

--- a/server.py
+++ b/server.py
@@ -1,0 +1,24 @@
+from wsgiref.simple_server import make_server
+import json
+_DEBUG_FILE = 'Amazon2021.08.04-09-41.json' #出力したいjsonファイル
+# Eclipse IDE専用プログラム出力
+_INFO_SUM = 10
+
+with open(_DEBUG_FILE, 'r', encoding='utf-8_sig') as f:
+    jsn = json.load(f)
+
+ 
+ 
+def app(environ, start_response):
+  status = '200 OK'
+  headers = [
+    ('Content-type', 'application/json; charset=utf-8'),
+    ('Access-Control-Allow-Origin', '*'),
+  ]
+  start_response(status, headers)
+ 
+  return [json.dumps(jsn, indent=int(_INFO_SUM), ensure_ascii=False).encode("utf-8")]
+ 
+with make_server('', 3000, app) as httpd:
+  print("Serving on port 3000...")
+  httpd.serve_forever()


### PR DESCRIPTION
#最低限の概要
1. スクレイピングで使用するブラウザの起動をヘッドレス(バックグラウンドで起動)に変更
2. Json出力の際,1冊1冊をオブジェクト型?(id付)にしたもの(_dict)と羅列のみをしているJson(_list)の2種類を出力するように変更
3. APIサーバ(Port:3000)の追加(jsonモジュールでdumpsしたものをそのまま配信するように作成)

#margeを受け入れる条件
特に無し